### PR TITLE
PR: StreamManager: add GetFeedInit

### DIFF
--- a/ModelsAPI/StreamManager.cpp
+++ b/ModelsAPI/StreamManager.cpp
@@ -205,6 +205,16 @@ CStream* CStreamManager::GetFeed(const std::string& _name)
 	return GetObject(m_feedsWork, _name);
 }
 
+const CStream* CStreamManager::GetFeedInit(const std::string& _name) const
+{
+	return GetObject(m_feedsInit, _name);
+}
+
+CStream* CStreamManager::GetFeedInit(const std::string& _name)
+{
+	return GetObject(m_feedsInit, _name);
+}
+
 std::vector<const CStream*> CStreamManager::GetFeedsInit() const
 {
 	return GetObjects(m_feedsInit);

--- a/ModelsAPI/StreamManager.h
+++ b/ModelsAPI/StreamManager.h
@@ -100,6 +100,10 @@ public:
 	const CStream* GetFeed(const std::string& _name) const;
 	// Returns a feed with the specified name. If such feed does not exist, returns nullptr.
 	CStream* GetFeed(const std::string& _name);
+	// Returns an inital feed with the specified name. If such feed does not exist, returns nullptr.
+	const CStream* GetFeedInit(const std::string& _name) const;
+	// Returns an inital feed with the specified name. If such feed does not exist, returns nullptr.
+	CStream* GetFeedInit(const std::string& _name);
 	// Returns all defined initial feeds.
 	std::vector<const CStream*> GetFeedsInit() const;
 	// Returns all defined initial feeds.


### PR DESCRIPTION
I am using the core without ui.
You actually need to set them, otherwise the flowsheet init will error, when it checks the inital state.
Even though all streams have the needed data.