### PR TITLE
PR: add script to allow updating scripts to VS2022

### DIFF
--- a/ExternalLibraries/UpdateScriptsToVisualStudio2022.bat
+++ b/ExternalLibraries/UpdateScriptsToVisualStudio2022.bat
@@ -1,0 +1,3 @@
+REM filepath: UpdateScriptsToVisualStudio2022.bat
+powershell -executionpolicy bypass -File .\UpdateScriptsToVisualStudio2022.ps1
+pause

--- a/ExternalLibraries/UpdateScriptsToVisualStudio2022.ps1
+++ b/ExternalLibraries/UpdateScriptsToVisualStudio2022.ps1
@@ -1,0 +1,21 @@
+# Updates Visual Studio version in all compilation scripts
+
+$filestoUpdate = @(
+    "CompileZLib.ps1",
+    "CompileSundials.ps1",
+    "CompileHDF5.ps1",
+    "CompileGraphviz.ps1"
+)
+
+foreach ($file in $filestoUpdate) {
+    if (Test-Path $file) {
+        Write-Host "Updating $file..."
+        $content = Get-Content $file
+        $content = $content -replace "Visual Studio 16 2019", "Visual Studio 17 2022"
+        $content | Set-Content $file -Force
+    } else {
+        Write-Host "Warning: $file not found"
+    }
+}
+
+Write-Host "Update completed"


### PR DESCRIPTION
If you want to use Dyssol with VS2022:

Visual Studio 2022 can handle the upgrade of the solution alone.

ExternalLibraries is the only part which you currently need to modify per hand,
So here is a small script to automate it.


If you later want to update everything to 2022 on github, you can delete this script.

![grafik](https://github.com/user-attachments/assets/b601f966-7e58-4e0d-8204-fbaa72c66697)
